### PR TITLE
Document Qualys agent usage for Nexpose ingestion

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,6 +7,10 @@ RESOURCE_GROUP=
 LOCATION=
 # Name of the Key Vault that stores secrets for Nexpose
 KEY_VAULT_NAME=
+# Secrets expected in the Key Vault for the Qualys/Nexpose ingestion agent
+# - nexpose-api-url
+# - nexpose-user
+# - nexpose-password
 # Endpoint for the ingestion API or other services
 API_ENDPOINT=
 # Base URL for the orchestrator API (default http://localhost:8000)

--- a/01_Architecture/MRA_Vulnerability_Management.md
+++ b/01_Architecture/MRA_Vulnerability_Management.md
@@ -90,7 +90,7 @@ Orchestrator AI Agent [icon: robot, label: "FastAPI Orchestrator AI Agent"]
 
 Ingestion Agents [color: blue, icon: robot] {
 
-Nexpose AI Agent [icon: robot, label: "Nexpose"]
+Qualys Ingestion Agent [icon: robot, label: "Nexpose (Qualys)"]
 
 Wiz AI Agent [icon: robot, label: "Wiz"]
 
@@ -196,7 +196,7 @@ Ticketing Agent --> Azure Cosmos DB : "log ticket"
 
 // KEY VAULT SECRETS (dotted arrows)
 
-"Nexpose AI Agent ...> Azure Key Vault : "get secrets""
+"Qualys Ingestion Agent ...> Azure Key Vault : "get secrets""
 
 "Wiz AI Agent ...> Azure Key Vault : "get secrets""
 
@@ -307,7 +307,9 @@ This section details each major component and agent in the architecture, specify
 ### 3.3 Ingestion Agents
 
 - **Purpose:**
-  Connects to vulnerability scanners (Nexpose, Wiz, Defender, WebApp Scanner), fetches findings, and normalizes results.
+Connects to vulnerability scanners (Nexpose, Wiz, Defender, WebApp Scanner), fetches findings, and normalizes results.
+In this environment the **Qualys Ingestion Agent** is reused to connect to Nexpose/InsightVM.
+Connection details and credentials are pulled from Azure Key Vault using the secrets `nexpose-api-url`, `nexpose-user`, and `nexpose-password`. All scanner credentials reside only in Key Vault.
 
 - **Inputs:**
   API credentials, scan parameters (date range, asset scope).

--- a/02_Diagrams/Architecture_Diagram.md
+++ b/02_Diagrams/Architecture_Diagram.md
@@ -33,7 +33,7 @@ Orchestrator AI Agent [icon: robot, label: "FastAPI Orchestrator AI Agent"]
 
 Ingestion Agents [color: blue, icon: robot] {
 
-Nexpose AI Agent [icon: robot, label: "Nexpose"]
+Qualys Ingestion Agent [icon: robot, label: "Nexpose (Qualys)"]
 
 Wiz AI Agent [icon: robot, label: "Wiz"]
 
@@ -139,7 +139,7 @@ Ticketing Agent --> Azure Cosmos DB : "log ticket"
 
 // KEY VAULT SECRETS (dotted arrows)
 
-"Nexpose AI Agent ...> Azure Key Vault : "get secrets""
+"Qualys Ingestion Agent ...> Azure Key Vault : "get secrets""
 
 "Wiz AI Agent ...> Azure Key Vault : "get secrets""
 

--- a/04_API_Contracts/ingestion_api_openapi.yaml
+++ b/04_API_Contracts/ingestion_api_openapi.yaml
@@ -1,5 +1,11 @@
 ---
 openapi: 3.0.0
+"""
+The Qualys Ingestion Agent is used as the Nexpose/InsightVM ingestion agent.
+Connection details and credentials are retrieved from Azure Key Vault using the
+secrets `nexpose-api-url`, `nexpose-user` and `nexpose-password`. All
+credentials must be managed only via Key Vault.
+"""
 info:
   title: Ingestion API
   version: 1.0.0

--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ See full architecture and data flows in [MRA_Vulnerability_Management.md](01_Arc
 The web-based UI included here is repurposed from a Microsoft solution
 accelerator and now acts as the front-end orchestrator for this template.
 
-For this deployment, the ingestion agent connects to **Nexpose (InsightVM)** using secrets stored in Azure Key Vault.
+For this deployment, the **Qualys Ingestion Agent** functions as the
+Nexpose/InsightVM ingestion agent. Connection details and credentials are
+fetched from Azure Key Vault using the secrets `nexpose-api-url`,
+`nexpose-user`, and `nexpose-password`. **All credentials are managed only via
+Key Vault.**
 
 ### Workflow Stages and Agent Roles
 

--- a/src/templates/config_template.env
+++ b/src/templates/config_template.env
@@ -3,3 +3,7 @@
 API_ENDPOINT=https://example.com
 # Name of the Key Vault containing Nexpose secrets
 KEY_VAULT_NAME=your-key-vault
+# Secrets expected in the Key Vault for the Qualys/Nexpose ingestion agent
+# - nexpose-api-url
+# - nexpose-user
+# - nexpose-password


### PR DESCRIPTION
## Summary
- clarify that the Qualys Ingestion Agent handles Nexpose/InsightVM in README
- note required Key Vault secrets in sample env files
- update architecture docs and diagram to show Qualys agent
- document Key Vault usage in the ingestion API contract

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887ecd2d544833182521b347aaac498