### PR TITLE
Fix ingestion Dockerfile port and add health endpoint

### DIFF
--- a/src/agents/ingestion/Dockerfile
+++ b/src/agents/ingestion/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /app
 COPY ../../../requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 COPY . .
-CMD ["uvicorn", "ingestion_agent:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "ingestion_agent:app", "--host", "0.0.0.0", "--port", "80"]

--- a/src/agents/ingestion/ingestion_agent.py
+++ b/src/agents/ingestion/ingestion_agent.py
@@ -63,6 +63,12 @@ class Finding(BaseModel):
 
 app = FastAPI(title="Ingestion Agent API")
 
+
+@app.get("/", tags=["health"])
+def healthcheck() -> dict:
+    """Basic healthcheck endpoint."""
+    return {"status": "ok"}
+
 # Example finding returned by the endpoint
 EXAMPLE_FINDING = {
     "vuln_id": "CVE-2025-12345",


### PR DESCRIPTION
## Summary
- add health check route to ingestion agent
- update ingestion agent Dockerfile to listen on port 80

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688810e3fd10833185113871f27f40b3