### PR TITLE
Add sample image flag

### DIFF
--- a/05_Infrastructure/containerapps.bicep
+++ b/05_Infrastructure/containerapps.bicep
@@ -6,12 +6,25 @@ param frontendAppName string
 param triageName string
 param remediationName string
 param reportingName string
-param orchestratorImage string = '${registryLoginServer}/orchestrator:latest'
-param ingestionImage string = '${registryLoginServer}/ingestion:latest'
-param frontendImage string = '${registryLoginServer}/frontend:latest'
-param triageImage string = '${registryLoginServer}/triage:latest'
-param remediationImage string = '${registryLoginServer}/remediation:latest'
-param reportingImage string = '${registryLoginServer}/reporting:latest'
+param useSampleImages bool = false
+param orchestratorImage string = useSampleImages
+  ? 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
+  : '${registryLoginServer}/orchestrator:latest'
+param ingestionImage string = useSampleImages
+  ? 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
+  : '${registryLoginServer}/ingestion:latest'
+param frontendImage string = useSampleImages
+  ? 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
+  : '${registryLoginServer}/frontend:latest'
+param triageImage string = useSampleImages
+  ? 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
+  : '${registryLoginServer}/triage:latest'
+param remediationImage string = useSampleImages
+  ? 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
+  : '${registryLoginServer}/remediation:latest'
+param reportingImage string = useSampleImages
+  ? 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
+  : '${registryLoginServer}/reporting:latest'
 param minReplicas int = 1
 param maxReplicas int = 1
 param cpu string = '0.5'

--- a/05_Infrastructure/main.bicep
+++ b/05_Infrastructure/main.bicep
@@ -10,12 +10,25 @@ param cosmosAccountName string
 param keyVaultName string
 param openAiAccountName string
 param containerRegistryName string
-param orchestratorImage string = '${containerRegistryName}.azurecr.io/orchestrator:latest'
-param ingestionImage string = '${containerRegistryName}.azurecr.io/ingestion:latest'
-param frontendImage string = '${containerRegistryName}.azurecr.io/frontend:latest'
-param triageImage string = '${containerRegistryName}.azurecr.io/triage:latest'
-param remediationImage string = '${containerRegistryName}.azurecr.io/remediation:latest'
-param reportingImage string = '${containerRegistryName}.azurecr.io/reporting:latest'
+param useSampleImages bool = false
+param orchestratorImage string = useSampleImages
+  ? 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
+  : '${containerRegistryName}.azurecr.io/orchestrator:latest'
+param ingestionImage string = useSampleImages
+  ? 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
+  : '${containerRegistryName}.azurecr.io/ingestion:latest'
+param frontendImage string = useSampleImages
+  ? 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
+  : '${containerRegistryName}.azurecr.io/frontend:latest'
+param triageImage string = useSampleImages
+  ? 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
+  : '${containerRegistryName}.azurecr.io/triage:latest'
+param remediationImage string = useSampleImages
+  ? 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
+  : '${containerRegistryName}.azurecr.io/remediation:latest'
+param reportingImage string = useSampleImages
+  ? 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
+  : '${containerRegistryName}.azurecr.io/reporting:latest'
 param minReplicas int = 1
 param maxReplicas int = 1
 param cpu string = '0.5'
@@ -67,6 +80,7 @@ module apps './containerapps.bicep' = {
     triageName: triageAppName
     remediationName: remediationAppName
     reportingName: reportingAppName
+    useSampleImages: useSampleImages
     orchestratorImage: orchestratorImage
     ingestionImage: ingestionImage
     frontendImage: frontendImage

--- a/06_DevOps/deployment_scripts/azd_up.sh
+++ b/06_DevOps/deployment_scripts/azd_up.sh
@@ -14,8 +14,14 @@ ENV_NAME="${ENV_NAME:-vm-env}"
 LOCATION="${LOCATION:-eastus}"
 SUBSCRIPTION="${AZURE_SUBSCRIPTION_ID:-}"
 
-ORCH_IMG="${ORCHESTRATOR_IMAGE:-mcr.microsoft.com/azuredocs/containerapps-helloworld:latest}"
-INGEST_IMG="${INGESTION_IMAGE:-mcr.microsoft.com/azuredocs/containerapps-helloworld:latest}"
+USE_SAMPLE_IMAGES="${USE_SAMPLE_IMAGES:-}"
+if [ -z "$USE_SAMPLE_IMAGES" ]; then
+  if [[ "${ENV_NAME,,}" =~ prod ]]; then
+    USE_SAMPLE_IMAGES="false"
+  else
+    USE_SAMPLE_IMAGES="true"
+  fi
+fi
 
 ARGS=(--environment "$ENV_NAME" --location "$LOCATION")
 if [ -n "$SUBSCRIPTION" ]; then
@@ -23,8 +29,7 @@ if [ -n "$SUBSCRIPTION" ]; then
 fi
 
 azd up "${ARGS[@]}" \
-  --infra-parameter orchestratorImage="$ORCH_IMG" \
-  --infra-parameter ingestionImage="$INGEST_IMG" \
+  --infra-parameter useSampleImages="$USE_SAMPLE_IMAGES" \
   --infra-parameter minReplicas=1 \
   --infra-parameter maxReplicas=1 \
   --infra-parameter cpu='0.5' \

--- a/README.md
+++ b/README.md
@@ -61,11 +61,12 @@ build backend containers consistently.
    The Jest-based tests automatically launch `frontend_server.py` to serve the UI during the run.
 5. **Copy `.env.sample` to `.env`** and fill in environment-specific secrets and endpoints.
 6. **Review and update `/05_Infrastructure/` Bicep templates** as needed. The
-   container app module exposes parameters for `orchestratorImage`,
-   `ingestionImage`, `minReplicas`, `maxReplicas`, `cpu`, and `memory` which can
-   be customized. Replace the default `containerapps-helloworld` images with the
-   container images you build and push to your Azure Container Registry, or
-   supply them at deploy time using the `--infra-parameter` option.
+  container app module exposes parameters for `orchestratorImage`,
+  `ingestionImage`, `minReplicas`, `maxReplicas`, `cpu`, and `memory` which can
+  be customized. A `useSampleImages` flag lets you deploy sample
+  `containerapps-helloworld` containers when you haven't built your own images.
+  Replace the defaults with images pushed to your Azure Container Registry or
+  supply parameters at deploy time using the `--infra-parameter` option.
 7. **Add your resource group configuration**
    After creating a new repo from this template, add an `infra:` section to
    `azure.yaml` specifying your Azure Resource Group before running `azd up`:


### PR DESCRIPTION
## Summary
- allow using sample images for container apps
- propagate `useSampleImages` bicep parameter
- default to sample images in `azd_up.sh` for non-prod envs
- document the new flag

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68881a6a153c83319a40b6a159c413ad