### PR TITLE
Add Dockerfiles for agent services

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ can optionally install using `uv` locally:
 ```bash
 uv pip install -r src/frontend/uv.lock
 ```
-Dockerfiles are provided under `src/orchestrator` and `src/agents/ingestion` to
-build backend containers consistently.
+Dockerfiles are provided for each backend agent under `src/agents/*` and in
+`src/orchestrator` to build container images consistently.
 4. **Install frontend dependencies and run tests:**
    ```bash
    cd src/frontend

--- a/src/agents/remediation/Dockerfile
+++ b/src/agents/remediation/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY ../../../requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+COPY . .
+CMD ["uvicorn", "remediation_service:app", "--host", "0.0.0.0", "--port", "80"]

--- a/src/agents/remediation/remediation_service.py
+++ b/src/agents/remediation/remediation_service.py
@@ -1,0 +1,10 @@
+from fastapi import FastAPI
+from . import RemediationAgent
+
+app = FastAPI(title="Remediation Agent API")
+
+@app.post("/api/remediate")
+def remediate_endpoint(payload: dict) -> dict:
+    """Create a remediation ticket."""
+    agent = RemediationAgent(config={})
+    return agent.remediate(payload)

--- a/src/agents/reporting/Dockerfile
+++ b/src/agents/reporting/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY ../../../requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+COPY . .
+CMD ["uvicorn", "reporting_service:app", "--host", "0.0.0.0", "--port", "80"]

--- a/src/agents/reporting/reporting_service.py
+++ b/src/agents/reporting/reporting_service.py
@@ -1,0 +1,10 @@
+from fastapi import FastAPI
+from . import ReportingAgent
+
+app = FastAPI(title="Reporting Agent API")
+
+@app.get("/api/report")
+def report_endpoint() -> dict:
+    """Return a simple report."""
+    agent = ReportingAgent(config={})
+    return agent.report([])

--- a/src/agents/triage/Dockerfile
+++ b/src/agents/triage/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY ../../../requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+COPY . .
+CMD ["uvicorn", "triage_service:app", "--host", "0.0.0.0", "--port", "80"]

--- a/src/agents/triage/triage_service.py
+++ b/src/agents/triage/triage_service.py
@@ -1,0 +1,10 @@
+from fastapi import FastAPI
+from . import TriageAgent
+
+app = FastAPI(title="Triage Agent API")
+
+@app.post("/api/triage")
+def triage_endpoint(finding: dict) -> dict:
+    """Return a triaged finding."""
+    agent = TriageAgent(config={})
+    return agent.triage(finding)


### PR DESCRIPTION
## Summary
- implement simple FastAPI servers for triage, remediation and reporting agents
- add Dockerfiles for new agent containers
- document Dockerfiles in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68883e8be4208331abbe12b61af8517f