### PR TITLE
Return real Nexpose data

### DIFF
--- a/src/agents/ingestion/__init__.py
+++ b/src/agents/ingestion/__init__.py
@@ -1,19 +1,21 @@
 from src.templates import BaseAgent
 
-from .ingestion_agent import EXAMPLE_FINDING, fetch_nexpose_assets
+from .ingestion_agent import EXAMPLE_FINDING, fetch_nexpose_assets, _parse_assets
 
 
 class IngestionAgent(BaseAgent):
     """Fetches vulnerabilities from scanners."""
 
     def ingest(self, start_date, end_date):
-        """Fetch findings from Nexpose and return example data."""
-        # For demonstration, we trigger a Nexpose API call and ignore the result.
-        # The actual findings returned to callers remain static.
+        """Fetch findings from Nexpose."""
         try:
             import anyio
 
-            anyio.run(fetch_nexpose_assets)
+            data = anyio.run(fetch_nexpose_assets)
+            if data:
+                results = _parse_assets(data)
+                if results:
+                    return [f.dict() for f in results]
         except Exception:  # noqa: BLE001
             pass
 


### PR DESCRIPTION
## Summary
- add parsing helper for Nexpose assets
- use real Nexpose data when available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688844abe8488331b9ea20eaf5226814