### PR TITLE
Refactor agents for standalone FastAPI services

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,12 +1,12 @@
 """Agent package exposing individual agent classes."""
 
-from .approval import ApprovalAgent
-from .deduplication import DeduplicationAgent
-from .enrichment import EnrichmentAgent
-from .ingestion import IngestionAgent
-from .remediation import RemediationAgent
-from .reporting import ReportingAgent
-from .triage import TriageAgent
+from src.agents.approval import ApprovalAgent
+from src.agents.deduplication import DeduplicationAgent
+from src.agents.enrichment import EnrichmentAgent
+from src.agents.ingestion import IngestionAgent
+from src.agents.remediation import RemediationAgent
+from src.agents.reporting import ReportingAgent
+from src.agents.triage import TriageAgent
 
 __all__ = [
     "IngestionAgent",

--- a/src/agents/remediation/__init__.py
+++ b/src/agents/remediation/__init__.py
@@ -1,13 +1,3 @@
-try:
-    from src.templates import BaseAgent
-except ModuleNotFoundError:  # allow running standalone
-    from templates import BaseAgent
+from src.agents.remediation.remediation_agent import RemediationAgent
 
-
-class RemediationAgent(BaseAgent):
-    """Creates tickets in ITSM platforms."""
-
-    def remediate(self, finding: dict):
-        """Return a dummy ticket for the finding."""
-        ticket_id = f"TICKET-{finding.get('vuln_id', '0')}"
-        return {"ticket_id": ticket_id, "status": "created"}
+__all__ = ["RemediationAgent"]

--- a/src/agents/remediation/remediation_agent.py
+++ b/src/agents/remediation/remediation_agent.py
@@ -1,0 +1,10 @@
+from src.templates import BaseAgent
+
+
+class RemediationAgent(BaseAgent):
+    """Creates tickets in ITSM platforms."""
+
+    def remediate(self, finding: dict) -> dict:
+        """Return a dummy ticket for the finding."""
+        ticket_id = f"TICKET-{finding.get('vuln_id', '0')}"
+        return {"ticket_id": ticket_id, "status": "created"}

--- a/src/agents/remediation/remediation_service.py
+++ b/src/agents/remediation/remediation_service.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from . import RemediationAgent
+from src.agents.remediation.remediation_agent import RemediationAgent
 
 app = FastAPI(title="Remediation Agent API")
 

--- a/src/agents/reporting/__init__.py
+++ b/src/agents/reporting/__init__.py
@@ -1,12 +1,3 @@
-try:
-    from src.templates import BaseAgent
-except ModuleNotFoundError:  # allow running standalone
-    from templates import BaseAgent
+from src.agents.reporting.reporting_agent import ReportingAgent
 
-
-class ReportingAgent(BaseAgent):
-    """Generates reports and dashboards."""
-
-    def report(self, data):
-        """Return a simple summary report."""
-        return {"total_items": len(data)}
+__all__ = ["ReportingAgent"]

--- a/src/agents/reporting/reporting_agent.py
+++ b/src/agents/reporting/reporting_agent.py
@@ -1,0 +1,9 @@
+from src.templates import BaseAgent
+
+
+class ReportingAgent(BaseAgent):
+    """Generates reports and dashboards."""
+
+    def report(self, data) -> dict:
+        """Return a simple summary report."""
+        return {"total_items": len(data)}

--- a/src/agents/reporting/reporting_service.py
+++ b/src/agents/reporting/reporting_service.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from . import ReportingAgent
+from src.agents.reporting.reporting_agent import ReportingAgent
 
 app = FastAPI(title="Reporting Agent API")
 

--- a/src/agents/triage/__init__.py
+++ b/src/agents/triage/__init__.py
@@ -1,15 +1,3 @@
-try:
-    from src.templates import BaseAgent
-except ModuleNotFoundError:  # allow running standalone
-    from templates import BaseAgent
+from src.agents.triage.triage_agent import TriageAgent
 
-
-class TriageAgent(BaseAgent):
-    """Assigns risk scores using Azure OpenAI."""
-
-    def triage(self, finding: dict):
-        """Return finding with a dummy risk score."""
-        score = len(str(finding)) % 5
-        result = dict(finding)
-        result["risk_score"] = score
-        return result
+__all__ = ["TriageAgent"]

--- a/src/agents/triage/triage_agent.py
+++ b/src/agents/triage/triage_agent.py
@@ -1,0 +1,12 @@
+from src.templates import BaseAgent
+
+
+class TriageAgent(BaseAgent):
+    """Assigns risk scores using Azure OpenAI."""
+
+    def triage(self, finding: dict) -> dict:
+        """Return finding with a dummy risk score."""
+        score = len(str(finding)) % 5
+        result = dict(finding)
+        result["risk_score"] = score
+        return result

--- a/src/agents/triage/triage_service.py
+++ b/src/agents/triage/triage_service.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from . import TriageAgent
+from src.agents.triage.triage_agent import TriageAgent
 
 app = FastAPI(title="Triage Agent API")
 

--- a/src/orchestrator/__init__.py
+++ b/src/orchestrator/__init__.py
@@ -50,3 +50,6 @@ class Orchestrator:
             "tickets": tickets,
             "report": report,
         }
+
+
+__all__ = ["Orchestrator"]

--- a/src/orchestrator/agents/remediation/__init__.py
+++ b/src/orchestrator/agents/remediation/__init__.py
@@ -1,13 +1,3 @@
-try:
-    from src.templates import BaseAgent
-except ModuleNotFoundError:  # allow running standalone
-    from templates import BaseAgent
+from src.orchestrator.agents.remediation.remediation_agent import RemediationAgent
 
-
-class RemediationAgent(BaseAgent):
-    """Creates tickets in ITSM platforms."""
-
-    def remediate(self, finding: dict):
-        """Return a dummy ticket for the finding."""
-        ticket_id = f"TICKET-{finding.get('vuln_id', '0')}"
-        return {"ticket_id": ticket_id, "status": "created"}
+__all__ = ["RemediationAgent"]

--- a/src/orchestrator/agents/remediation/remediation_agent.py
+++ b/src/orchestrator/agents/remediation/remediation_agent.py
@@ -1,0 +1,10 @@
+from src.templates import BaseAgent
+
+
+class RemediationAgent(BaseAgent):
+    """Creates tickets in ITSM platforms."""
+
+    def remediate(self, finding: dict) -> dict:
+        """Return a dummy ticket for the finding."""
+        ticket_id = f"TICKET-{finding.get('vuln_id', '0')}"
+        return {"ticket_id": ticket_id, "status": "created"}

--- a/src/orchestrator/agents/remediation/remediation_service.py
+++ b/src/orchestrator/agents/remediation/remediation_service.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from . import RemediationAgent
+from src.orchestrator.agents.remediation.remediation_agent import RemediationAgent
 
 app = FastAPI(title="Remediation Agent API")
 

--- a/src/orchestrator/agents/reporting/__init__.py
+++ b/src/orchestrator/agents/reporting/__init__.py
@@ -1,12 +1,3 @@
-try:
-    from src.templates import BaseAgent
-except ModuleNotFoundError:  # allow running standalone
-    from templates import BaseAgent
+from src.orchestrator.agents.reporting.reporting_agent import ReportingAgent
 
-
-class ReportingAgent(BaseAgent):
-    """Generates reports and dashboards."""
-
-    def report(self, data):
-        """Return a simple summary report."""
-        return {"total_items": len(data)}
+__all__ = ["ReportingAgent"]

--- a/src/orchestrator/agents/reporting/reporting_agent.py
+++ b/src/orchestrator/agents/reporting/reporting_agent.py
@@ -1,0 +1,9 @@
+from src.templates import BaseAgent
+
+
+class ReportingAgent(BaseAgent):
+    """Generates reports and dashboards."""
+
+    def report(self, data) -> dict:
+        """Return a simple summary report."""
+        return {"total_items": len(data)}

--- a/src/orchestrator/agents/reporting/reporting_service.py
+++ b/src/orchestrator/agents/reporting/reporting_service.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from . import ReportingAgent
+from src.orchestrator.agents.reporting.reporting_agent import ReportingAgent
 
 app = FastAPI(title="Reporting Agent API")
 

--- a/src/orchestrator/agents/triage/__init__.py
+++ b/src/orchestrator/agents/triage/__init__.py
@@ -1,15 +1,3 @@
-try:
-    from src.templates import BaseAgent
-except ModuleNotFoundError:  # allow running standalone
-    from templates import BaseAgent
+from src.orchestrator.agents.triage.triage_agent import TriageAgent
 
-
-class TriageAgent(BaseAgent):
-    """Assigns risk scores using Azure OpenAI."""
-
-    def triage(self, finding: dict):
-        """Return finding with a dummy risk score."""
-        score = len(str(finding)) % 5
-        result = dict(finding)
-        result["risk_score"] = score
-        return result
+__all__ = ["TriageAgent"]

--- a/src/orchestrator/agents/triage/triage_agent.py
+++ b/src/orchestrator/agents/triage/triage_agent.py
@@ -1,0 +1,12 @@
+from src.templates import BaseAgent
+
+
+class TriageAgent(BaseAgent):
+    """Assigns risk scores using Azure OpenAI."""
+
+    def triage(self, finding: dict) -> dict:
+        """Return finding with a dummy risk score."""
+        score = len(str(finding)) % 5
+        result = dict(finding)
+        result["risk_score"] = score
+        return result

--- a/src/orchestrator/agents/triage/triage_service.py
+++ b/src/orchestrator/agents/triage/triage_service.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from . import TriageAgent
+from src.orchestrator.agents.triage.triage_agent import TriageAgent
 
 app = FastAPI(title="Triage Agent API")
 


### PR DESCRIPTION
## Summary
- split agent logic for remediation, reporting, and triage into separate modules
- update service entrypoints to use absolute imports
- switch package `__init__` files to absolute imports and define `__all__`
- update orchestrator agent packages accordingly
- keep ingestion agent logic the same except for fetch functions

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68893f075e98833196e4002d13219018